### PR TITLE
Add service skeletons and Docker Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+AUTH_TOKEN=your_auth_token
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_MODEL=gpt-4o-mini
+# Copy this file to .env before running:
+# cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # venda-AI
+
+## Running with Docker Compose
+
+1. Copy `.env.example` to `.env` and fill in the required values:
+   ```bash
+   cp .env.example .env
+   ```
+2. Build and start all services:
+   ```bash
+   docker compose up --build
+   ```
+3. Open the web client in your browser at [http://localhost:5173](http://localhost:5173).

--- a/asr/Dockerfile
+++ b/asr/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/asr/requirements.txt
+++ b/asr/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/asr/server.py
+++ b/asr/server.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"service": "asr"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+version: "3.9"
+
+services:
+  asr:
+    build: ./asr
+    ports:
+      - "5001:8000"
+    env_file: [.env]
+    volumes:
+      - shared-data:/data
+
+  mt:
+    build: ./mt
+    ports:
+      - "5002:8000"
+    env_file: [.env]
+    volumes:
+      - shared-data:/data
+
+  llm:
+    build: ./llm
+    ports:
+      - "5003:8000"
+    env_file: [.env]
+    volumes:
+      - shared-data:/data
+
+  tts:
+    build: ./tts
+    ports:
+      - "5004:8000"
+    env_file: [.env]
+    volumes:
+      - shared-data:/data
+
+  gateway:
+    build: ./gateway
+    ports:
+      - "8000:8000"
+    env_file: [.env]
+    depends_on:
+      - asr
+      - mt
+      - llm
+      - tts
+    volumes:
+      - shared-data:/data
+
+  web-client:
+    build: ./web-client
+    ports:
+      - "5173:8000"
+    env_file: [.env]
+    depends_on:
+      - gateway
+    volumes:
+      - shared-data:/data
+
+volumes:
+  shared-data:

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/gateway/server.py
+++ b/gateway/server.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"service": "gateway"}

--- a/llm/Dockerfile
+++ b/llm/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/llm/requirements.txt
+++ b/llm/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/llm/server.py
+++ b/llm/server.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"service": "llm"}

--- a/mt/Dockerfile
+++ b/mt/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/mt/requirements.txt
+++ b/mt/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/mt/server.py
+++ b/mt/server.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"service": "mt"}

--- a/tts/Dockerfile
+++ b/tts/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tts/requirements.txt
+++ b/tts/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/tts/server.py
+++ b/tts/server.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def root():
+    return {"service": "tts"}

--- a/web-client/Dockerfile
+++ b/web-client/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py .
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/web-client/requirements.txt
+++ b/web-client/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/web-client/server.py
+++ b/web-client/server.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+app = FastAPI()
+
+@app.get("/", response_class=HTMLResponse)
+async def index():
+    return "<h1>Web Client</h1>"


### PR DESCRIPTION
## Summary
- scaffold ASR, MT, LLM, TTS, gateway, and web-client services with FastAPI stubs and Dockerfiles
- add docker-compose orchestration and shared environment configuration
- document Docker Compose workflow and environment variables

## Testing
- `python -m py_compile asr/server.py mt/server.py llm/server.py tts/server.py gateway/server.py web-client/server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f66f2c228832e811e55d3f677d268