### PR TITLE
Pin FastAPI and Uvicorn versions

### DIFF
--- a/asr/requirements.txt
+++ b/asr/requirements.txt
@@ -1,2 +1,2 @@
-fastapi
-uvicorn[standard]
+fastapi==0.116.1
+uvicorn[standard]==0.35.0

--- a/gateway/requirements.txt
+++ b/gateway/requirements.txt
@@ -1,2 +1,2 @@
-fastapi
-uvicorn[standard]
+fastapi==0.116.1
+uvicorn[standard]==0.35.0

--- a/llm/requirements.txt
+++ b/llm/requirements.txt
@@ -1,2 +1,2 @@
-fastapi
-uvicorn[standard]
+fastapi==0.116.1
+uvicorn[standard]==0.35.0

--- a/mt/requirements.txt
+++ b/mt/requirements.txt
@@ -1,2 +1,2 @@
-fastapi
-uvicorn[standard]
+fastapi==0.116.1
+uvicorn[standard]==0.35.0

--- a/tts/requirements.txt
+++ b/tts/requirements.txt
@@ -1,2 +1,2 @@
-fastapi
-uvicorn[standard]
+fastapi==0.116.1
+uvicorn[standard]==0.35.0

--- a/web-client/requirements.txt
+++ b/web-client/requirements.txt
@@ -1,2 +1,2 @@
-fastapi
-uvicorn[standard]
+fastapi==0.116.1
+uvicorn[standard]==0.35.0


### PR DESCRIPTION
## Summary
- pin FastAPI to 0.116.1 and Uvicorn[standard] to 0.35.0 across service requirements

## Testing
- `docker compose build` *(fails: bash: command not found: docker)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689f68fbfd28832e875a5a05446bcd23