### PR TITLE
chore: add dockerignore files for services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Editor files
+*.swp
+
+# Environment files
+.env
+.env.*
+venv/
+.venv/
+
+# Build and cache artifacts
+build/
+dist/
+.cache/
+
+# IDE directories
+.vscode/
+.idea/
+
+# Git
+.git
+.gitignore

--- a/asr/.dockerignore
+++ b/asr/.dockerignore
@@ -1,0 +1,25 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Editor files
+*.swp
+
+# Environment files
+.env
+.env.*
+venv/
+.venv/
+
+# Build and cache artifacts
+build/
+dist/
+.cache/
+
+# IDE directories
+.vscode/
+.idea/
+
+# Git
+.git
+.gitignore

--- a/gateway/.dockerignore
+++ b/gateway/.dockerignore
@@ -1,0 +1,25 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Editor files
+*.swp
+
+# Environment files
+.env
+.env.*
+venv/
+.venv/
+
+# Build and cache artifacts
+build/
+dist/
+.cache/
+
+# IDE directories
+.vscode/
+.idea/
+
+# Git
+.git
+.gitignore

--- a/llm/.dockerignore
+++ b/llm/.dockerignore
@@ -1,0 +1,25 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Editor files
+*.swp
+
+# Environment files
+.env
+.env.*
+venv/
+.venv/
+
+# Build and cache artifacts
+build/
+dist/
+.cache/
+
+# IDE directories
+.vscode/
+.idea/
+
+# Git
+.git
+.gitignore

--- a/mt/.dockerignore
+++ b/mt/.dockerignore
@@ -1,0 +1,25 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Editor files
+*.swp
+
+# Environment files
+.env
+.env.*
+venv/
+.venv/
+
+# Build and cache artifacts
+build/
+dist/
+.cache/
+
+# IDE directories
+.vscode/
+.idea/
+
+# Git
+.git
+.gitignore

--- a/tts/.dockerignore
+++ b/tts/.dockerignore
@@ -1,0 +1,25 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Editor files
+*.swp
+
+# Environment files
+.env
+.env.*
+venv/
+.venv/
+
+# Build and cache artifacts
+build/
+dist/
+.cache/
+
+# IDE directories
+.vscode/
+.idea/
+
+# Git
+.git
+.gitignore

--- a/web-client/.dockerignore
+++ b/web-client/.dockerignore
@@ -1,0 +1,25 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Editor files
+*.swp
+
+# Environment files
+.env
+.env.*
+venv/
+.venv/
+
+# Build and cache artifacts
+build/
+dist/
+.cache/
+
+# IDE directories
+.vscode/
+.idea/
+
+# Git
+.git
+.gitignore


### PR DESCRIPTION
## Summary
- add shared `.dockerignore` with common exclusions
- add identical `.dockerignore` to each service directory

## Testing
- ⚠️ `docker build -t venda-asr asr` (command not found)
- ⚠️ `apt-get update` (403 repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_689f68fd977c832ebd0c04b15678579d