### PR TITLE
Add service health endpoints and checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@
    docker compose up --build
    ```
 3. Open the web client in your browser at [http://localhost:5173](http://localhost:5173).
+
+## Health Checks
+
+Each service provides a `/health` endpoint that returns `{"status": "ok"}`. Docker Compose is configured to call these endpoints to verify container health.

--- a/asr/server.py
+++ b/asr/server.py
@@ -5,3 +5,8 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"service": "asr"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,12 @@ services:
     env_file: [.env]
     volumes:
       - shared-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
   mt:
     build: ./mt
@@ -16,6 +22,12 @@ services:
     env_file: [.env]
     volumes:
       - shared-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
   llm:
     build: ./llm
@@ -24,6 +36,12 @@ services:
     env_file: [.env]
     volumes:
       - shared-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
   tts:
     build: ./tts
@@ -32,6 +50,12 @@ services:
     env_file: [.env]
     volumes:
       - shared-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
   gateway:
     build: ./gateway
@@ -45,6 +69,12 @@ services:
       - tts
     volumes:
       - shared-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
   web-client:
     build: ./web-client
@@ -55,6 +85,12 @@ services:
       - gateway
     volumes:
       - shared-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
 
 volumes:
   shared-data:

--- a/gateway/server.py
+++ b/gateway/server.py
@@ -5,3 +5,8 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"service": "gateway"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/llm/server.py
+++ b/llm/server.py
@@ -5,3 +5,8 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"service": "llm"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/mt/server.py
+++ b/mt/server.py
@@ -5,3 +5,8 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"service": "mt"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/tts/server.py
+++ b/tts/server.py
@@ -5,3 +5,8 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"service": "tts"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/web-client/server.py
+++ b/web-client/server.py
@@ -6,3 +6,8 @@ app = FastAPI()
 @app.get("/", response_class=HTMLResponse)
 async def index():
     return "<h1>Web Client</h1>"
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `/health` endpoint returning status to each FastAPI service
- add Docker Compose health checks hitting these endpoints
- document health check behavior in README

## Testing
- `python -m py_compile asr/server.py gateway/server.py llm/server.py mt/server.py tts/server.py web-client/server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f690275f8832e92ffc20144063875